### PR TITLE
Internal Android build

### DIFF
--- a/.github/workflows/cd_android.yml
+++ b/.github/workflows/cd_android.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: 'zulu'
           java-version: 11
       - name: Cache Gradle Wrapper
         uses: actions/cache@v3
@@ -27,7 +27,7 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
-      - name: Install the signing certificate 
+      - name: Install the signing certificate
         env:
           DISTRIBUTION_CERTIFICATE_ANDROID_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
         run: |
@@ -77,7 +77,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: 'zulu'
           java-version: 11
       - name: Cache Gradle Wrapper
         uses: actions/cache@v3
@@ -98,7 +98,7 @@ jobs:
           echo "export VERSION_NAME=$versionName; export VERSION_CODE=$versionCode" > ~/.env_version
 
       - name: Deploy to Firebase
-        env: 
+        env:
           FIREBASE_APP_ID_ANDROID: ${{secrets.FIREBASE_APP_ID_ANDROID}}
           GOOGLE_APPLICATION_CREDENTIALS_KEY: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
         run: |
@@ -107,7 +107,7 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS=$GITHUB_WORKSPACE/google-app-creds.json
           source ~/.env_version
           cd examples/mobile/android && gradle appDistributionUploadRelease --stacktrace
-          
+
   Android-Play-Store-Distribution:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: Android-App-Build
@@ -121,7 +121,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: 'zulu'
           java-version: 11
       - name: Cache Gradle Wrapper
         uses: actions/cache@v3
@@ -141,3 +141,55 @@ jobs:
         run: |
           export ANDROID_PUBLISHER_CREDENTIALS=$ANDROID_PUBLISHER_CREDENTIALS
           cd examples/mobile/android && chmod +x ./gradlew && ./gradlew publishBundle --artifact-dir ./app/build/outputs/bundle/release/ --stacktrace
+
+  Android-App-Internal-Build:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install modules
+        run: yarn install
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Install the signing certificate
+        env:
+          DISTRIBUTION_CERTIFICATE_ANDROID_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          CERTIFICATE_PATH=./examples/mobile/android/app/release.keystore
+          echo -n "$DISTRIBUTION_CERTIFICATE_ANDROID_BASE64" | base64 --decode > $CERTIFICATE_PATH
+
+      - name: calculate version
+        run: |
+          versionName='1.0.'$GITHUB_RUN_NUMBER
+          versionCode=$GITHUB_RUN_NUMBER; echo "versionName: $versionName; versionCode: $versionCode"
+          echo "export VERSION_NAME=$versionName; export VERSION_CODE=$versionCode" > ~/.env_version
+
+      - name: Assign internal environment
+        env:
+          INTERNAL_RELEASE_TOKEN_URLS: ${{secrets.INTERNAL_RELEASE_TOKEN_URLS}}
+        run: |
+          truncate -s 0 packages/mobile/src/providers/TokenUrl.tsx
+          echo $INTERNAL_RELEASE_TOKEN_URLS >> packages/mobile/src/providers/TokenUrl.tsx
+
+      - name: Internal Android App Build
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.RELEASE_KEYSTORE_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_KEY_PASSWORD }}
+        run: |
+          export KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD
+          export KEY_ALIAS=$KEY_ALIAS
+          export KEY_PASSWORD=$KEY_PASSWORD
+          source ~/.env_version
+          cd examples/mobile/android && ENVFILE=.env && gradle assembleRelease bundleRelease --stacktrace


### PR DESCRIPTION
- Job to create internal build for Android is created
- urls are taken from secrets and used in RN
- same step Assign internal environment can be used for iOS
- distribution of the internal build(s) will be covered in separate PRs