### PR TITLE
Update github action name for ruby

### DIFF
--- a/.github/workflows/cd_ios.yml
+++ b/.github/workflows/cd_ios.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install modules
         run: yarn install
 
-      - name: Setup bundler
-        uses: actions/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1.126.0
         with:
           ruby-version: 3.1.2
 
@@ -60,7 +60,7 @@ jobs:
         run: yarn install
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.126.0
         with:
           ruby-version: 3.1.2
 
@@ -105,8 +105,8 @@ jobs:
       - name: Install modules
         run: yarn install
 
-      - name: Setup bundler
-        uses: actions/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1.126.0
         with:
           ruby-version: 3.1.2
 


### PR DESCRIPTION
# Description:

Update github action name for ruby -> `actions/setup-ruby@v1` is deprecated